### PR TITLE
Use find_packages() for recursive module discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 __pycache__/
+build/
+idioms.egg-info/
+codealign/
+__pycache__/
+*.egg-info/
+*.pyc

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,1 @@
+# Root-level idioms package init

--- a/idioms/__init__.py
+++ b/idioms/__init__.py
@@ -1,0 +1,1 @@
+# idioms.idioms subpackage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "idioms"
+version = "0.0.1"
+
+[tool.setuptools]
+package-dir = {"idioms" = "."}
+packages = ["idioms", "idioms.idioms", "idioms.idioms.data", "idioms.idioms.data.idastubs"]

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,5 @@ from setuptools import setup, find_packages
 setup(
     name="idioms",
     version="0.0.1",
-    package_dir={"idioms": "."},  # Map current directory as 'idioms' package
-    packages=["idioms", "idioms.idioms", "idioms.idioms.data", "idioms.idioms.data.idastubs"],
+    packages=find_packages(),
 )

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(
     name="idioms",
     version="0.0.1",
-    packages=['idioms', 'idioms.data'],
+    packages=find_packages(),
 )

--- a/setup.py
+++ b/setup.py
@@ -3,5 +3,6 @@ from setuptools import setup, find_packages
 setup(
     name="idioms",
     version="0.0.1",
-    packages=find_packages(),
+    package_dir={"idioms": "."},  # Map current directory as 'idioms' package
+    packages=["idioms", "idioms.idioms", "idioms.idioms.data", "idioms.idioms.data.idastubs"],
 )


### PR DESCRIPTION
Changes setup.py to use find_packages() so all submodules are automatically discovered and installed. I had trouble importing a submodule without this change.